### PR TITLE
Scenario error handling

### DIFF
--- a/core/src/main/scala/canoe/api/Scenario.scala
+++ b/core/src/main/scala/canoe/api/Scenario.scala
@@ -17,7 +17,7 @@ import fs2.Pipe
   */
 final class Scenario[F[_], A] private (private val episode: Episode[F, TelegramMessage, A]) extends AnyVal {
 
-  def pipe: Pipe[F, TelegramMessage, A] = episode.pipe
+  def pipe: Pipe[F, TelegramMessage, A] = episode.matching
 
   def flatMap[B](fn: A => Scenario[F, B]): Scenario[F, B] =
     new Scenario[F, B](episode.flatMap(fn(_).episode))
@@ -61,6 +61,9 @@ final class Scenario[F[_], A] private (private val episode: Episode[F, TelegramM
     */
   def cancelWith[Any](expect: Expect[Any])(cancellation: TelegramMessage => F[Unit]): Scenario[F, A] =
     new Scenario[F, A](episode.cancelWith(expect.isDefinedAt)(cancellation))
+
+  def attempt: Scenario[F, Either[Throwable, A]] =
+    new Scenario[F, Either[Throwable, A]](episode.attempt)
 }
 
 object Scenario {

--- a/core/src/main/scala/canoe/api/Scenario.scala
+++ b/core/src/main/scala/canoe/api/Scenario.scala
@@ -3,7 +3,8 @@ package canoe.api
 import canoe.api.matching.Episode
 import canoe.models.messages.TelegramMessage
 import canoe.syntax.Expect
-import cats.{Monad, StackSafeMonad}
+import cats.syntax.applicativeError._
+import cats.{ApplicativeError, Monad, MonadError, StackSafeMonad}
 import fs2.Pipe
 
 /**
@@ -62,6 +63,15 @@ final class Scenario[F[_], A] private (private val episode: Episode[F, TelegramM
   def cancelWith[Any](expect: Expect[Any])(cancellation: TelegramMessage => F[Unit]): Scenario[F, A] =
     new Scenario[F, A](episode.cancelWith(expect.isDefinedAt)(cancellation))
 
+  /**
+    * @return `this` or scenario which is result of `fn` if error occurs.
+    */
+  def handleErrorWith(fn: Throwable => Scenario[F, A]): Scenario[F, A] =
+    new Scenario[F, A](episode.handleErrorWith(fn(_).episode))
+
+  /**
+    * @return Scenario which wraps successful result values in `Right` and raised errors in `Left`.
+    */
   def attempt: Scenario[F, Either[Throwable, A]] =
     new Scenario[F, Either[Throwable, A]](episode.attempt)
 }
@@ -101,6 +111,20 @@ object Scenario {
     new Scenario[F, A](Episode.pure(a))
 
   def done[F[_]]: Scenario[F, Unit] = pure(())
+
+  implicit def monadErrorInstance[F[_]: ApplicativeError[*[_], Throwable]]: MonadError[Scenario[F, *], Throwable] =
+    new MonadError[Scenario[F, *], Throwable] with StackSafeMonad[Scenario[F, *]] {
+      def pure[A](a: A): Scenario[F, A] = Scenario.pure(a)
+
+      def flatMap[A, B](scenario: Scenario[F, A])(fn: A => Scenario[F, B]): Scenario[F, B] =
+        scenario.flatMap(fn)
+
+      def raiseError[A](e: Throwable): Scenario[F, A] =
+        Scenario.eval(e.raiseError[F, A])
+
+      def handleErrorWith[A](scenario: Scenario[F, A])(fn: Throwable => Scenario[F, A]): Scenario[F, A] =
+        scenario.handleErrorWith(fn)
+    }
 
   implicit def monadInstance[F[_]]: Monad[Scenario[F, *]] =
     new StackSafeMonad[Scenario[F, *]] {

--- a/core/src/main/scala/canoe/api/matching/Episode.scala
+++ b/core/src/main/scala/canoe/api/matching/Episode.scala
@@ -124,7 +124,6 @@ object Episode {
   private[api] implicit def monadErrorInstance[F[_]: ApplicativeError[*[_], Throwable], I]
     : MonadError[Episode[F, I, *], Throwable] =
     new MonadError[Episode[F, I, *], Throwable] with StackSafeMonad[Episode[F, I, *]] {
-      println("Constructing monad error instance")
 
       def pure[A](a: A): Episode[F, I, A] = Pure(a)
 
@@ -139,7 +138,6 @@ object Episode {
 
   private[api] implicit def monadInstance[F[_], I]: Monad[Episode[F, I, *]] =
     new StackSafeMonad[Episode[F, I, *]] {
-      println("Constructing monad instance")
 
       def pure[A](a: A): Episode[F, I, A] = Pure(a)
 
@@ -238,6 +236,7 @@ object Episode {
 
       case Bind(prev, fn) =>
         find(prev, input, cancelTokens).flatMap {
+          // Have to explicitly handle all not matched cases in order to satisfy compile
           case (Matched(a), rest)   => find(fn(a), rest, cancelTokens)
           case (Missed(m), rest)    => Stream(Missed(m) -> rest)
           case (Cancelled(m), rest) => Stream(Cancelled(m) -> rest)

--- a/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
@@ -11,8 +11,8 @@ object EpisodeCheckInstances {
   implicit def eqEpisode[I: Arbitrary, O]: Eq[Episode[IO, I, O]] = {
     val sampleInput: List[I] = Gen.listOf(Arbitrary.arbitrary[I]).sample.get
 
-    def result(ep: Episode[IO, I, O]): List[O] =
-      Stream.emits(sampleInput).through(ep.matching).toList()
+    def result(ep: Episode[IO, I, O]): List[Either[Throwable, O]] =
+      Stream.emits(sampleInput).through(ep.attempt.matching).toList()
 
     (x: Episode[IO, I, O], y: Episode[IO, I, O]) =>
       result(x) == result(y)

--- a/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
@@ -12,12 +12,14 @@ object EpisodeCheckInstances {
     val sampleInput: List[I] = Gen.listOf(Arbitrary.arbitrary[I]).sample.get
 
     def result(ep: Episode[IO, I, O]): List[O] =
-      Stream.emits(sampleInput).through(ep.pipe).toList()
+      Stream.emits(sampleInput).through(ep.matching).toList()
 
     (x: Episode[IO, I, O], y: Episode[IO, I, O]) =>
       result(x) == result(y)
   }
 
+  implicit val eqThrowable: Eq[Throwable] =
+    (x: Throwable, y: Throwable) => (x ne null) == (y ne null)
 
   implicit def arbEpisode[F[_], I, O: Arbitrary]: Arbitrary[Episode[F, I, O]] =
     Arbitrary(

--- a/core/src/test/scala/canoe/api/matching/EpisodeLawsCheck.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeLawsCheck.scala
@@ -9,10 +9,14 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.typelevel.discipline.scalatest.Discipline
 
 class EpisodeLawsCheck extends AnyFunSuite with Discipline {
-  // By re-declaring implicit Monad instance here we ensure that it will be used during monad tests
+
+  // By re-declaring implicit Monad instance here we ensure that it will be used during monad tests,
   // instead of MonadError instance
   implicit def monadInstance[F[_], I]: Monad[Episode[F, I, *]] = Episode.monadInstance
-  checkAll("Episode.Monad laws", MonadTests[Episode[IO, Int, *]].monad[Int, Int, Int])
 
-  checkAll("Episode.MonadError laws", MonadErrorTests[Episode[IO, Int, *], Throwable].monadError[Int, Int, Int])
+  checkAll("Monad[Episode[IO, Int, *]]",
+    MonadTests[Episode[IO, Int, *]].monad[Int, Int, Int])
+
+  checkAll("MonadError[Episode[IO, Int, *], Throwable]",
+    MonadErrorTests[Episode[IO, Int, *], Throwable].monadError[Int, Int, Int])
 }

--- a/core/src/test/scala/canoe/api/matching/EpisodeLawsCheck.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeLawsCheck.scala
@@ -1,12 +1,18 @@
 package canoe.api.matching
 
 import canoe.api.matching.EpisodeCheckInstances._
+import cats.Monad
 import cats.effect.IO
 import cats.implicits._
-import cats.laws.discipline.MonadTests
+import cats.laws.discipline._
 import org.scalatest.funsuite.AnyFunSuite
 import org.typelevel.discipline.scalatest.Discipline
 
 class EpisodeLawsCheck extends AnyFunSuite with Discipline {
-  checkAll("Episode.MonadLaws", MonadTests[Episode[IO, Int, *]].monad[Int, Int, Int])
+  // By re-declaring implicit Monad instance here we ensure that it will be used during monad tests
+  // instead of MonadError instance
+  implicit def monadInstance[F[_], I]: Monad[Episode[F, I, *]] = Episode.monadInstance
+  checkAll("Episode.Monad laws", MonadTests[Episode[IO, Int, *]].monad[Int, Int, Int])
+
+  checkAll("Episode.MonadError laws", MonadErrorTests[Episode[IO, Int, *], Throwable].monadError[Int, Int, Int])
 }


### PR DESCRIPTION
Contains changes for `Episode` and `Scenario` types:
* provided error handling methods such as `handleErrorWith` and `attempt`
* added `MonadError` instance having `ApplicativeError` for `F`
