### PR TITLE
Scenario-Episode relations

### DIFF
--- a/core/src/main/scala/canoe/api/matching/Episode.scala
+++ b/core/src/main/scala/canoe/api/matching/Episode.scala
@@ -44,47 +44,6 @@ private[api] sealed trait Episode[F[_], -I, +O] {
     Bind(this, fn)
 
   def map[O2](fn: O => O2): Episode[F, I, O2] = flatMap(fn.andThen(Pure(_)))
-
-  /**
-    * @return Episode which is cancellable by the occurrence of input element described
-    *         by predicate `p` at any point after the episode is started and before it is finished
-    */
-  def cancelOn[I2 <: I](p: I2 => Boolean): Episode[F, I2, O] =
-    Cancellable(this, p, None)
-
-  /**
-    * @param p Predicate which determines what input value causes cancellation
-    * @param cancellation Function which result is going to be evaluated during the cancellation
-    *
-    * @return Episode which is cancellable by the occurrence of input element described
-    *         by predicate `p` at any point after the episode is started and before it is finished,
-    *         and evaluates `cancellation` when such element occurs.
-    */
-  def cancelWith[I2 <: I](
-    p: I2 => Boolean
-  )(cancellation: I2 => F[Unit]): Episode[F, I2, O] =
-    Cancellable(this, p, Some(cancellation))
-
-  /**
-    * @return Episode which ignores the input element, which causes
-    *         missed result, `n` time and evaluates `fn` for every such element
-    */
-  def tolerateN[I2 <: I](n: Int)(fn: I2 => F[Unit]): Episode[F, I2, O] =
-    Tolerate(this, Some(n), fn)
-
-  /**
-    * @return Episode which ignores every input element which causes
-    *         missed result and evaluates `fn` for every such element
-    */
-  def tolerateAll[I2 <: I](fn: I2 => F[Unit]): Episode[F, I2, O] =
-    Tolerate(this, None, fn)
-
-  def handleErrorWith[I2 <: I, O2 >: O](f: Throwable => Episode[F, I2, O2]): Episode[F, I2, O2] =
-    Protected(this, f)
-
-  def attempt: Episode[F, I, Either[Throwable, O]] =
-    map(Right(_): Either[Throwable, O]).handleErrorWith(e => Episode.Pure(Left(e)))
-
 }
 
 object Episode {
@@ -122,7 +81,7 @@ object Episode {
         fa.flatMap(f)
 
       def handleErrorWith[A](fa: Episode[F, I, A])(f: Throwable => Episode[F, I, A]): Episode[F, I, A] =
-        fa.handleErrorWith(f)
+        Protected(fa, f)
 
       def raiseError[A](e: Throwable): Episode[F, I, A] = Eval(e.raiseError[F, A])
     }

--- a/core/src/main/scala/canoe/api/matching/Episode.scala
+++ b/core/src/main/scala/canoe/api/matching/Episode.scala
@@ -83,43 +83,34 @@ private[api] sealed trait Episode[F[_], -I, +O] {
     Protected(this, f)
 
   def attempt: Episode[F, I, Either[Throwable, O]] =
-    map(Right(_): Either[Throwable, O]).handleErrorWith(e => Episode.pure(Left(e)))
+    map(Right(_): Either[Throwable, O]).handleErrorWith(e => Episode.Pure(Left(e)))
 
 }
 
-private final case class Pure[F[_], I, A](a: A) extends Episode[F, I, A]
-
-private final case class Eval[F[_], I, A](fa: F[A]) extends Episode[F, I, A]
-
-private final case class Next[F[_], A](p: A => Boolean) extends Episode[F, A, A]
-
-private final case class First[F[_], A](p: A => Boolean) extends Episode[F, A, A]
-
-private final case class Protected[F[_], I, O1, O2 >: O1](episode: Episode[F, I, O1],
-                                                          onError: Throwable => Episode[F, I, O2])
-    extends Episode[F, I, O2]
-
-private final case class Bind[F[_], I, O1, O2](episode: Episode[F, I, O1], fn: O1 => Episode[F, I, O2])
-    extends Episode[F, I, O2]
-
-private final case class Cancellable[F[_], I, O](
-  episode: Episode[F, I, O],
-  cancelOn: I => Boolean,
-  finalizer: Option[I => F[Unit]]
-) extends Episode[F, I, O]
-
-private final case class Tolerate[F[_], I, O](episode: Episode[F, I, O], limit: Option[Int], fn: I => F[Unit])
-    extends Episode[F, I, O]
-
 object Episode {
 
-  private[api] def pure[F[_], I, A](a: A): Episode[F, I, A] = Pure(a)
+  private[api] final case class Pure[F[_], I, A](a: A) extends Episode[F, I, A]
 
-  private[api] def eval[F[_], I, A](fa: F[A]): Episode[F, I, A] = Eval(fa)
+  private[api] final case class Eval[F[_], I, A](fa: F[A]) extends Episode[F, I, A]
 
-  private[api] def first[F[_], I](p: I => Boolean): Episode[F, I, I] = First(p)
+  private[api] final case class Next[F[_], A](p: A => Boolean) extends Episode[F, A, A]
 
-  private[api] def next[F[_], I](p: I => Boolean): Episode[F, I, I] = Next(p)
+  private[api] final case class First[F[_], A](p: A => Boolean) extends Episode[F, A, A]
+
+  private[api] final case class Protected[F[_], I, O1, O2 >: O1](episode: Episode[F, I, O1],
+                                                                 onError: Throwable => Episode[F, I, O2])
+      extends Episode[F, I, O2]
+
+  private[api] final case class Bind[F[_], I, O1, O2](episode: Episode[F, I, O1], fn: O1 => Episode[F, I, O2])
+      extends Episode[F, I, O2]
+
+  private[api] final case class Cancellable[F[_], I, O](episode: Episode[F, I, O],
+                                                        cancelOn: I => Boolean,
+                                                        finalizer: Option[I => F[Unit]])
+      extends Episode[F, I, O]
+
+  private[api] final case class Tolerate[F[_], I, O](episode: Episode[F, I, O], limit: Option[Int], fn: I => F[Unit])
+      extends Episode[F, I, O]
 
   private[api] implicit def monadErrorInstance[F[_]: ApplicativeError[*[_], Throwable], I]
     : MonadError[Episode[F, I, *], Throwable] =

--- a/core/src/test/scala/canoe/api/ScenarioCheckInstances.scala
+++ b/core/src/test/scala/canoe/api/ScenarioCheckInstances.scala
@@ -1,0 +1,50 @@
+package canoe.api
+
+import canoe.TestIO._
+import canoe.models.PrivateChat
+import canoe.models.messages.{TelegramMessage, TextMessage}
+import cats.Eq
+import cats.effect.IO
+import fs2.Stream
+import org.scalacheck.{Arbitrary, Gen}
+
+object ScenarioCheckInstances {
+  // Basically the same instances as in EpisodeCheckInstances
+
+  private def message(s: String): TextMessage =
+    TextMessage(-1, PrivateChat(-1, None, None, None), -1, s)
+
+  implicit def arbMessage: Arbitrary[TelegramMessage] =
+    Arbitrary(Arbitrary.arbString.arbitrary.map(message))
+
+  implicit def eqScenario[A]: Eq[Scenario[IO, A]] = {
+
+    val sampleInput: List[TelegramMessage] =
+      Gen.listOf(Arbitrary.arbitrary[TelegramMessage]).sample.get
+
+    def result(sc: Scenario[IO, A]): List[Either[Throwable, A]] =
+      Stream.emits(sampleInput).through(sc.attempt.pipe).toList()
+
+    (x: Scenario[IO, A], y: Scenario[IO, A]) =>
+      result(x) == result(y)
+  }
+
+  implicit val eqThrowable: Eq[Throwable] =
+    (x: Throwable, y: Throwable) => (x ne null) == (y ne null)
+
+  implicit def arbScenario[F[_], A: Arbitrary]: Arbitrary[Scenario[F, A]] =
+    Arbitrary(
+      Gen.oneOf(
+        Arbitrary.arbitrary[A].map(a => Scenario.pure[F, A](a)),
+        for {
+          b <- Arbitrary.arbBool.arbitrary
+          a <- Arbitrary.arbitrary[A]
+        } yield Scenario.start[F, A] { case _ if b => a },
+        for {
+          b <- Arbitrary.arbBool.arbitrary
+          a <- Arbitrary.arbitrary[A]
+        } yield Scenario.next[F, A] { case _ if b => a }
+      )
+    )
+
+}

--- a/core/src/test/scala/canoe/api/ScenarioLawsCheck.scala
+++ b/core/src/test/scala/canoe/api/ScenarioLawsCheck.scala
@@ -1,0 +1,22 @@
+package canoe.api
+
+import canoe.api.ScenarioCheckInstances._
+import cats.Monad
+import cats.effect.IO
+import cats.implicits._
+import cats.laws.discipline._
+import org.scalatest.funsuite.AnyFunSuite
+import org.typelevel.discipline.scalatest.Discipline
+
+class ScenarioLawsCheck extends AnyFunSuite with Discipline {
+
+  // By re-declaring implicit Monad instance here, we ensure that it will be used during monad tests,
+  // instead of MonadError instance
+  implicit def monadInstance[F[_], I]: Monad[Scenario[F, *]] = Scenario.monadInstance
+
+  checkAll("Monad[Scenario[IO, *]]",
+    MonadTests[Scenario[IO, *]].monad[Int, String, Int])
+
+  checkAll("MonadError[Scenario[IO, *], Throwable]",
+    MonadErrorTests[Scenario[IO, *], Throwable].monadError[String, Int, String])
+}

--- a/core/src/test/scala/canoe/api/ScenarioSpec.scala
+++ b/core/src/test/scala/canoe/api/ScenarioSpec.scala
@@ -1,0 +1,205 @@
+package canoe.api
+
+import canoe.TestIO._
+import canoe.models.PrivateChat
+import canoe.models.messages.TextMessage
+import canoe.syntax._
+import cats.effect.IO
+import fs2.Stream
+import org.scalatest.propspec.AnyPropSpec
+
+class ScenarioSpec extends AnyPropSpec {
+
+  private def message(s: String): TextMessage =
+    TextMessage(-1, PrivateChat(-1, None, None, None), -1, s)
+
+  property("Scenario.start consumes at least one message") {
+    val scenario: Scenario[IO, TextMessage] = Scenario.start(command("fire"))
+    val input = Stream.empty
+
+    assert(input.through(scenario.pipe).toList().isEmpty)
+  }
+
+  property("Scenario.first returns all matched occurrences") {
+    val trigger = "fire"
+    val scenario: Scenario[IO, TextMessage] = Scenario.start(textMessage.matching(trigger))
+
+    val input = Stream(
+      trigger,
+      trigger,
+      "dasd",
+      trigger
+    ).map(message)
+
+    assert(input.through(scenario.pipe).size() == input.toList().count(_.text == trigger))
+  }
+
+  property("Scenario.next consumes at least one message") {
+    val scenario: Scenario[IO, TextMessage] = Scenario.next(command("fire"))
+    val input = Stream.empty
+
+    assert(input.through(scenario.pipe).toList().isEmpty)
+  }
+
+  property("Scenario.next matches only the first message") {
+    val trigger = "fire"
+    val scenario: Scenario[IO, TextMessage] = Scenario.start(textMessage.endingWith(trigger))
+
+    val input = Stream(
+      s"1.$trigger",
+      s"2.$trigger"
+    ).map(message)
+
+    assert(input.through(scenario.pipe).value().text.startsWith("1"))
+  }
+
+  property("Scenario.next uses provided predicate to match the result") {
+    val scenario: Scenario[IO, TextMessage] = Scenario.start(textMessage.endingWith("fire"))
+    val input = Stream("").map(message)
+
+    assert(input.through(scenario.pipe).toList().isEmpty)
+  }
+
+  property("Scenario.eval doesn't consume any message") {
+    val scenario: Scenario[IO, Unit] = Scenario.eval(IO.unit)
+    val input = Stream.empty
+
+    assert(input.through(scenario.pipe).size() == 1)
+  }
+
+  property("Scenario.eval evaluates value in the effect") {
+    val scenario: Scenario[IO, Int] = Scenario.eval(IO.pure(12))
+
+    assert(Stream.empty.through(scenario.pipe).value() == 12)
+  }
+
+  property("Scenario.eval evaluates the effect when it is run") {
+    var evaluated = false
+    val scenario: Scenario[IO, Unit] = Scenario.eval(IO { evaluated = true })
+
+    Stream.empty.through(scenario.pipe).run()
+    assert(evaluated)
+  }
+
+  property("Scenario.eval evaluates the effect only once") {
+    var counter = 0
+    val scenario: Scenario[IO, Unit] = Scenario.eval(IO { counter += 1 })
+    Stream.empty.through(scenario.pipe).run()
+
+    assert(counter == 1)
+  }
+
+  property("Scenario.eval propagates error raised in underlying value") {
+    case class Error(s: String) extends Throwable
+    val scenario: Scenario[IO, Unit] = Scenario.eval(IO.raiseError(Error("test")))
+
+    assertThrows[Error](Stream.empty.through(scenario.pipe).run())
+  }
+
+  property("Scenario.handleErrorWith transforms into provided substitute in case of error") {
+    case class Error(s: String) extends Throwable
+    val episode: Scenario[IO, Int] =
+      Scenario
+        .eval[IO, Int](IO.raiseError(Error("test")))
+        .flatMap(_ => Scenario.eval(IO.pure(-1)))
+        .handleErrorWith(_ => Scenario.eval(IO.pure(12)))
+
+    assert(Stream.empty.through(episode.pipe).value() == 12)
+  }
+
+  property("Scenario.attempt wraps exception in left part of Either") {
+    case class Error(s: String) extends Throwable
+    val error = Error("test")
+
+    val scenario: Scenario[IO, Unit] = Scenario.eval(IO.raiseError(error))
+    assert(Stream.empty.through(scenario.attempt.pipe).value() == Left(error))
+  }
+
+  property("Scenario.attempt wraps result in right part of Either") {
+    val scenario: Scenario[IO, Int] = Scenario.eval(IO.pure(12))
+    assert(Stream.empty.through(scenario.attempt.pipe).value() == Right(12))
+  }
+
+  property("flatMap composes scenarios together") {
+    val scenario: Scenario[IO, Unit] =
+      for {
+        _ <- Scenario.start(textMessage.matching("one"))
+        _ <- Scenario.next(textMessage.matching("two"))
+      } yield ()
+
+    val input = Stream("one", "two").map(message)
+    assert(input.through(scenario.pipe).size() == 1)
+  }
+
+  property("Scenario doesn't ignore the element which is mismatched") {
+    val scenario: Scenario[IO, String] =
+      for {
+        m <- Scenario.start(textMessage.endingWith("one"))
+        _ <- Scenario.next(textMessage.endingWith("two"))
+      } yield m.text
+    val input = Stream("1.one", "2.one", "3.two").map(message)
+
+    assert(input.through(scenario.pipe).value().startsWith("2"))
+  }
+
+  property("Scenario can be cancelled while it's in progress") {
+    val cancelMessage = "cancel"
+    val scenario: Scenario[IO, Unit] =
+      for {
+        _ <- Scenario.start(any)
+        _ <- Scenario.next(any)
+      } yield ()
+
+    val cancellable = scenario.cancelOn(textMessage.matching(cancelMessage))
+    val input = Stream("1.one", cancelMessage).map(message)
+
+    assert(input.through(cancellable.pipe).size() == 0)
+  }
+
+  property("Scenario evaluates cancellation function when it is cancelled") {
+    var cancelled = false
+    val cancelMessage = "cancel"
+
+    val scenario: Scenario[IO, Unit] =
+      for {
+        _ <- Scenario.start(any)
+        _ <- Scenario.next(any)
+      } yield ()
+
+    val cancellable = scenario.cancelWith(textMessage.matching(cancelMessage)) { _ =>
+      IO { cancelled = true }
+    }
+
+    val input = Stream("1.one", cancelMessage).map(message)
+
+    input.through(cancellable.pipe).run()
+    assert(cancelled)
+  }
+
+  property("tolerate skips up to N elements if they don't match") {
+    val n = 5
+    val scenario: Scenario[IO, String] = Scenario.next(textMessage.endingWith("fire").map(_.text))
+    val input = Stream("").repeatN(n) ++ Stream(s"2.fire")
+    val tolerating = scenario.tolerateN(n)(_ => IO.unit)
+
+    assert(input.map(message).through(tolerating.pipe).value().startsWith("2"))
+  }
+
+  property("tolerate doesn't skip the element if it matches") {
+    val scenario: Scenario[IO, String] =
+      Scenario.next(textMessage.endingWith("fire").map(_.text)).tolerate(_ => IO.unit)
+    val input = Stream("1.fire", "2.fire").map(message)
+
+    assert(input.through(scenario.pipe).value().startsWith("1"))
+  }
+
+  property("tolerate evaluates provided effect each time it skips the element") {
+    var counter = 0
+    val scenario: Scenario[IO, String] = Scenario.next(textMessage.endingWith("fire").map(_.text))
+    val input = Stream("1", "2", "fire").map(message)
+    val tolerating = scenario.tolerateAll(_ => IO { counter += 1 })
+    input.through(tolerating.pipe).run()
+
+    assert(counter == 2)
+  }
+}

--- a/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
@@ -3,6 +3,7 @@ package canoe.api.matching
 import canoe.TestIO._
 import cats.Eq
 import cats.effect.IO
+import cats.syntax.applicativeError._
 import fs2.Stream
 import org.scalacheck.{Arbitrary, Gen}
 

--- a/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
@@ -24,15 +24,15 @@ object EpisodeCheckInstances {
   implicit def arbEpisode[F[_], I, O: Arbitrary]: Arbitrary[Episode[F, I, O]] =
     Arbitrary(
       Gen.oneOf(
-        Arbitrary.arbitrary[O].map(o => Episode.pure[F, I, O](o)),
+        Arbitrary.arbitrary[O].map(o => Episode.Pure[F, I, O](o)),
         for {
           b <- Arbitrary.arbBool.arbitrary
           o <- Arbitrary.arbitrary[O]
-        } yield Episode.first[F, I](_ => b).map(_ => o),
+        } yield Episode.First[F, I](_ => b).map(_ => o),
         for {
           b <- Arbitrary.arbBool.arbitrary
           o <- Arbitrary.arbitrary[O]
-        } yield Episode.next[F, I](_ => b).map(_ => o)
+        } yield Episode.Next[F, I](_ => b).map(_ => o)
       )
     )
 

--- a/core/src/test/scala/canoe/api/matching/EpisodeSpec.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeSpec.scala
@@ -20,7 +20,7 @@ class EpisodeSpec extends AnyFunSuite {
 
     val input = Stream("one", "two")
 
-    assert(input.through(episode.matching).toList().size == 1)
+    assert(input.through(episode.matching).size() == 1)
   }
 
   test("Episode doesn't ignore the element which is mismatched") {

--- a/core/src/test/scala/canoe/api/matching/EpisodeSpec.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeSpec.scala
@@ -11,11 +11,11 @@ class EpisodeSpec extends AnyFunSuite {
 
   val predicate: String => Boolean = _.endsWith(expected)
 
-  test("Episode.start >>= Episode.next") {
+  test("Episode.First >>= Episode.Next") {
     val episode: Episode[fs2.Pure, String, String] =
       for {
-        m <- Episode.first[fs2.Pure, String](_.endsWith("one"))
-        _ <- Episode.next[fs2.Pure, String](_.endsWith("two"))
+        m <- Episode.First[fs2.Pure, String](_.endsWith("one"))
+        _ <- Episode.Next[fs2.Pure, String](_.endsWith("two"))
       } yield m
 
     val input = Stream("one", "two")
@@ -26,8 +26,8 @@ class EpisodeSpec extends AnyFunSuite {
   test("Episode doesn't ignore the element which is mismatched") {
     val episode: Episode[fs2.Pure, String, String] =
       for {
-        m <- Episode.first[fs2.Pure, String](_.endsWith("one"))
-        _ <- Episode.next[fs2.Pure, String](_.endsWith("two"))
+        m <- Episode.First[fs2.Pure, String](_.endsWith("one"))
+        _ <- Episode.Next[fs2.Pure, String](_.endsWith("two"))
       } yield m
 
     val input = Stream("1.one", "2.one", "3.two")
@@ -40,8 +40,8 @@ class EpisodeSpec extends AnyFunSuite {
 
     val episode: Episode[fs2.Pure, String, String] =
       (for {
-        m <- Episode.first[fs2.Pure, String](_.endsWith("one"))
-        _ <- Episode.next[fs2.Pure, String](_ => true)
+        m <- Episode.First[fs2.Pure, String](_.endsWith("one"))
+        _ <- Episode.Next[fs2.Pure, String](_ => true)
       } yield m).cancelOn(_ == cancelToken)
 
     val input = Stream("1.one", cancelToken, "any")
@@ -55,8 +55,8 @@ class EpisodeSpec extends AnyFunSuite {
 
     val episode: Episode[IO, String, String] =
       (for {
-        m <- Episode.first[IO, String](_.endsWith("one"))
-        _ <- Episode.next[IO, String](_ => true)
+        m <- Episode.First[IO, String](_.endsWith("one"))
+        _ <- Episode.Next[IO, String](_ => true)
       } yield m).cancelWith[String](_ == cancelToken)(m => IO { cancelledWith = m })
 
     val input = Stream("1.one", cancelToken, "any")
@@ -65,15 +65,15 @@ class EpisodeSpec extends AnyFunSuite {
     assert(cancelledWith == cancelToken)
   }
 
-  test("Episode.start needs at least one message") {
-    val episode: Episode[fs2.Pure, String, String] = Episode.first(predicate)
+  test("Episode.First needs at least one message") {
+    val episode: Episode[fs2.Pure, String, String] = Episode.First(predicate)
     val input = Stream.empty
 
     assert(input.through(episode.matching).toList().isEmpty)
   }
 
-  test("Episode.start returns all matched occurrences") {
-    val episode: Episode[fs2.Pure, String, String] = Episode.first(predicate)
+  test("Episode.First returns all matched occurrences") {
+    val episode: Episode[fs2.Pure, String, String] = Episode.First(predicate)
     val input = Stream(
       s"1.$expected",
       s"1.$expected",
@@ -84,15 +84,15 @@ class EpisodeSpec extends AnyFunSuite {
     assert(input.through(episode.matching).size() == input.toList().count(predicate))
   }
 
-  test("Episode.next needs at least one message") {
-    val episode: Episode[fs2.Pure, String, String] = Episode.next(predicate)
+  test("Episode.Next needs at least one message") {
+    val episode: Episode[fs2.Pure, String, String] = Episode.Next(predicate)
     val input = Stream.empty
 
     assert(input.through(episode.matching).toList().isEmpty)
   }
 
-  test("Episode.next matches only the first message") {
-    val episode: Episode[fs2.Pure, String, String] = Episode.next(predicate)
+  test("Episode.Next matches only the first message") {
+    val episode: Episode[fs2.Pure, String, String] = Episode.Next(predicate)
 
     val input = Stream(s"1.$expected", s"2.$expected")
 
@@ -101,42 +101,42 @@ class EpisodeSpec extends AnyFunSuite {
     assert(results.head.startsWith("1"))
   }
 
-  test("Episode.next uses provided predicate to match the result") {
-    val episode: Episode[fs2.Pure, String, String] = Episode.next(predicate)
+  test("Episode.Next uses provided predicate to match the result") {
+    val episode: Episode[fs2.Pure, String, String] = Episode.Next(predicate)
     val input = Stream("")
 
     assert(input.through(episode.matching).toList().isEmpty)
   }
 
-  test("Episode.next#tolerate doesn't skip the element if it matches") {
+  test("Episode.Next#tolerate doesn't skip the element if it matches") {
     val episode: Episode[IO, String, String] =
-      Episode.next(predicate).tolerateN(1)(_ => IO.unit)
+      Episode.Next(predicate).tolerateN(1)(_ => IO.unit)
 
     val input = Stream(s"1.$expected", s"2.$expected")
 
     assert(input.through(episode.matching).toList().head.startsWith("1"))
   }
 
-  test("Episode.next#tolerateN skips up to N elements if they don't match") {
+  test("Episode.Next#tolerateN skips up to N elements if they don't match") {
     val n = 5
     val episode: Episode[IO, String, String] =
-      Episode.next(predicate).tolerateN(n)(_ => IO.unit)
+      Episode.Next(predicate).tolerateN(n)(_ => IO.unit)
 
     val input = Stream("").repeatN(5) ++ Stream(s"2.$expected")
 
     assert(input.through(episode.matching).toList().head.startsWith("2"))
   }
 
-  test("Episode.eval doesn't consume any message") {
-    val episode: Episode[IO, Unit, Unit] = Episode.eval(IO.unit)
+  test("Episode.Eval doesn't consume any message") {
+    val episode: Episode[IO, Unit, Unit] = Episode.Eval(IO.unit)
     val input: Stream[fs2.Pure, Unit] = Stream.empty
 
     assert(input.through(episode.matching).size == 1)
   }
 
-  test("Episode.eval evaluates effect") {
+  test("Episode.Eval evaluates effect") {
     var evaluated = false
-    val episode: Episode[IO, Unit, Unit] = Episode.eval(IO { evaluated = true })
+    val episode: Episode[IO, Unit, Unit] = Episode.Eval(IO { evaluated = true })
     val input: Stream[fs2.Pure, Unit] = Stream.empty
 
     input.through(episode.matching).run()
@@ -144,25 +144,25 @@ class EpisodeSpec extends AnyFunSuite {
     assert(evaluated)
   }
 
-  test("Episode.eval evaluates value in an effect") {
-    val episode: Episode[IO, Unit, Int] = Episode.eval(IO.pure(1))
+  test("Episode.Eval evaluates value in an effect") {
+    val episode: Episode[IO, Unit, Int] = Episode.Eval(IO.pure(1))
     val input: Stream[fs2.Pure, Unit] = Stream.empty
 
     assert(input.through(episode.matching).value() == 1)
   }
 
-  test("Episode.eval evaluates effect only once") {
+  test("Episode.Eval evaluates effect only once") {
     var times = 0
-    val episode: Episode[IO, Unit, Unit] = Episode.eval(IO { times = times + 1 })
+    val episode: Episode[IO, Unit, Unit] = Episode.Eval(IO { times = times + 1 })
     val input: Stream[fs2.Pure, Unit] = Stream.empty
 
     input.through(episode.matching).run()
     assert(times == 1)
   }
 
-  test("Episode.eval propagates error raised in underlying value") {
+  test("Episode.Eval propagates error raised in underlying value") {
     case class Error(s: String) extends Throwable
-    val episode: Episode[IO, Unit, Int] = Episode.eval(IO.raiseError(Error("test")))
+    val episode: Episode[IO, Unit, Int] = Episode.Eval(IO.raiseError(Error("test")))
 
     assertThrows[Error](Stream.empty.through(episode.matching).run())
   }
@@ -171,9 +171,9 @@ class EpisodeSpec extends AnyFunSuite {
     case class Error(s: String) extends Throwable
     val episode: Episode[IO, Unit, Int] =
       Episode
-        .eval(IO.raiseError(Error("test")))
-        .flatMap(_ => Episode.eval(IO.pure(-1)))
-        .handleErrorWith(_ => Episode.eval(IO.pure(12)))
+        .Eval[IO, Unit, Int](IO.raiseError(Error("test")))
+        .flatMap(_ => Episode.Eval[IO, Unit, Int](IO.pure(-1)))
+        .handleErrorWith(_ => Episode.Eval[IO, Unit, Int](IO.pure(12)))
 
     assert(Stream.empty.through(episode.matching).value() == 12)
   }
@@ -182,18 +182,18 @@ class EpisodeSpec extends AnyFunSuite {
     case class Error(s: String) extends Throwable
     val error = Error("test")
 
-    val episode: Episode[IO, Unit, Unit] = Episode.eval(IO.raiseError(error))
+    val episode: Episode[IO, Unit, Unit] = Episode.Eval(IO.raiseError(error))
     assert(Stream.empty.through(episode.attempt.matching).value() == Left(error))
   }
 
   test("Episode.attempt wraps result in right part of Either") {
-    val episode: Episode[IO, Unit, Int] = Episode.eval(IO.pure(12))
+    val episode: Episode[IO, Unit, Int] = Episode.Eval(IO.pure(12))
     assert(Stream.empty.through(episode.attempt.matching).value() == Right(12))
   }
 
   test("should not happen") {
     case class Error(s: String) extends Throwable
-    val episode: Episode[IO, Unit, Error] = Episode.eval(IO.pure(Error("test")))
+    val episode: Episode[IO, Unit, Error] = Episode.Eval(IO.pure(Error("test")))
     assert(Stream.empty.through(episode.matching).value() == Error("test"))
   }
 }


### PR DESCRIPTION
* The overlapping methods of `Scenario`/`Episode` were removed, with `Episode` being the internal algebra of `Scenario`.
* Law checks were added for `Scenario` `Monad`/`MonadError` instances as well