### PR TITLE
Scenario stack safety

### DIFF
--- a/core/src/main/scala/canoe/api/Scenario.scala
+++ b/core/src/main/scala/canoe/api/Scenario.scala
@@ -3,8 +3,9 @@ package canoe.api
 import canoe.api.matching.Episode
 import canoe.models.messages.TelegramMessage
 import canoe.syntax.Expect
+import cats.arrow.FunctionK
 import cats.syntax.applicativeError._
-import cats.{ApplicativeError, Monad, MonadError, StackSafeMonad}
+import cats.{ApplicativeError, Monad, MonadError, StackSafeMonad, ~>}
 import fs2.Pipe
 
 /**
@@ -89,6 +90,9 @@ final class Scenario[F[_], +A] private (private val ep: Episode[F, TelegramMessa
     */
   def cancelWith[Any](expect: Expect[Any])(cancellation: TelegramMessage => F[Unit]): Scenario[F, A] =
     new Scenario[F, A](Episode.Cancellable(ep, expect.isDefinedAt, Some(cancellation)))
+
+  def mapK[G[_]](f: F ~> G): Scenario[G, A] =
+    new Scenario[G, A](ep.mapK(f))
 }
 
 object Scenario {
@@ -151,4 +155,7 @@ object Scenario {
       def flatMap[A, B](scenario: Scenario[F, A])(fn: A => Scenario[F, B]): Scenario[F, B] =
         scenario.flatMap(fn)
     }
+
+  implicit def functionKInstance[F[_]]: F ~> Scenario[F, *] =
+    FunctionK.lift(Scenario.eval)
 }

--- a/core/src/main/scala/canoe/api/Scenario.scala
+++ b/core/src/main/scala/canoe/api/Scenario.scala
@@ -91,6 +91,12 @@ final class Scenario[F[_], +A] private (private val ep: Episode[F, TelegramMessa
   def cancelWith[Any](expect: Expect[Any])(cancellation: TelegramMessage => F[Unit]): Scenario[F, A] =
     new Scenario[F, A](Episode.Cancellable(ep, expect.isDefinedAt, Some(cancellation)))
 
+  /**
+    * Maps effect type from `F` to `G` using the supplied transformation.
+    *
+    * Warning: this operation can result into StackOverflowError
+    * if `this` is nested with a lot of `flatMap` operations.
+    */
   def mapK[G[_]](f: F ~> G): Scenario[G, A] =
     new Scenario[G, A](ep.mapK(f))
 }

--- a/core/src/main/scala/canoe/api/matching/Episode.scala
+++ b/core/src/main/scala/canoe/api/matching/Episode.scala
@@ -52,9 +52,9 @@ private[api] sealed trait Episode[F[_], -I, +O] {
 
 object Episode {
 
-  private[api] final case class Pure[F[_], I, A](a: A) extends Episode[F, I, A]
+  private[api] final case class Pure[F[_], A](a: A) extends Episode[F, Any, A]
 
-  private[api] final case class Eval[F[_], I, A](fa: F[A]) extends Episode[F, I, A]
+  private[api] final case class Eval[F[_], A](fa: F[A]) extends Episode[F, Any, A]
 
   private[api] final case class Next[F[_], A](p: A => Boolean) extends Episode[F, A, A]
 

--- a/core/src/main/scala/canoe/api/matching/Episode.scala
+++ b/core/src/main/scala/canoe/api/matching/Episode.scala
@@ -189,13 +189,15 @@ object Episode {
         }
 
       case Bind(prev, fn) =>
-        find(prev, input, cancelTokens).flatMap {
-          // Have to explicitly handle all not matched cases in order to satisfy compile
-          case (Matched(a), rest)   => find(fn(a), rest, cancelTokens)
-          case (Missed(m), rest)    => Stream(Missed(m) -> rest)
-          case (Cancelled(m), rest) => Stream(Cancelled(m) -> rest)
-          case (Failed(e), rest)    => Stream(Failed(e) -> rest)
-        }
+        Stream(prev)
+          .flatMap(ep => find(ep, input, cancelTokens))
+          .flatMap {
+            // Have to explicitly handle all not matched cases in order to satisfy compile
+            case (Matched(a), rest)   => find(fn(a), rest, cancelTokens)
+            case (Missed(m), rest)    => Stream(Missed(m) -> rest)
+            case (Cancelled(m), rest) => Stream(Cancelled(m) -> rest)
+            case (Failed(e), rest)    => Stream(Failed(e) -> rest)
+          }
     }
 
   private def translate[F[_], G[_], I, O](episode: Episode[F, I, O], f: F ~> G): Episode[G, I, O] =

--- a/core/src/test/scala/canoe/api/ScenarioSpec.scala
+++ b/core/src/test/scala/canoe/api/ScenarioSpec.scala
@@ -202,4 +202,17 @@ class ScenarioSpec extends AnyPropSpec {
 
     assert(counter == 2)
   }
+
+  property("Scenario is stack safe during the interpretation") {
+    def stack[F[_]](n: Long): Scenario[F, Long] = {
+      def bind(n: Long, sc: Scenario[F, Long]): Scenario[F, Long] =
+        if (n <= 0) sc
+        else bind(n - 1, sc.flatMap(l => Scenario.pure(l + 1)))
+
+      bind(n, Scenario.pure(0))
+    }
+
+    val n = 100000L
+    assert(Stream.empty.through(stack[IO](n).pipe).value() == n)
+  }
 }

--- a/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeCheckInstances.scala
@@ -25,7 +25,7 @@ object EpisodeCheckInstances {
   implicit def arbEpisode[F[_], I, O: Arbitrary]: Arbitrary[Episode[F, I, O]] =
     Arbitrary(
       Gen.oneOf(
-        Arbitrary.arbitrary[O].map(o => Episode.Pure[F, I, O](o)),
+        Arbitrary.arbitrary[O].map(o => Episode.Pure[F, O](o)),
         for {
           b <- Arbitrary.arbBool.arbitrary
           o <- Arbitrary.arbitrary[O]

--- a/core/src/test/scala/canoe/api/matching/EpisodeSpec.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeSpec.scala
@@ -185,4 +185,17 @@ class EpisodeSpec extends AnyFunSuite {
 
     assert(Stream.empty.through(episode.matching).value() == 12)
   }
+
+  test("Episode is stack safe during the interpretation") {
+    def stack(n: Long): Episode[IO, Any, Long] = {
+      def bind(n: Long, ep: Episode[IO, Any, Long]): Episode[IO, Any, Long] =
+        if (n <= 0) ep
+        else bind(n - 1, ep.flatMap(l => Episode.Pure(l + 1)))
+
+      bind(n, Episode.Pure[IO, Any, Long](0L))
+    }
+
+    val n = 100000L
+    assert(Stream.empty.through(stack(n).matching).value() == n)
+  }
 }

--- a/core/src/test/scala/canoe/api/matching/EpisodeSpec.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeSpec.scala
@@ -177,9 +177,9 @@ class EpisodeSpec extends AnyFunSuite {
     case class Error(s: String) extends Throwable
 
     val failing: Episode[IO, Unit, Int] =
-      Episode.Eval[IO, Unit, Int](IO.raiseError(Error("test")))
-        .flatMap(_ => Episode.Eval[IO, Unit, Int](IO.pure(-1)))
-    val recover = Episode.Eval[IO, Unit, Int](IO.pure(12))
+      Episode.Eval[IO, Int](IO.raiseError(Error("test")))
+        .flatMap(_ => Episode.Eval[IO, Int](IO.pure(-1)))
+    val recover = Episode.Eval[IO, Int](IO.pure(12))
 
     val episode = Episode.Protected(failing, _ => recover)
 
@@ -192,7 +192,7 @@ class EpisodeSpec extends AnyFunSuite {
         if (n <= 0) ep
         else bind(n - 1, ep.flatMap(l => Episode.Pure(l + 1)))
 
-      bind(n, Episode.Pure[IO, Any, Long](0L))
+      bind(n, Episode.Pure[IO, Long](0L))
     }
 
     val n = 100000L


### PR DESCRIPTION
* Guarantees stack safety during `Scenario` interpretation 
* Adds `mapK` to the `Scenario` interface
Fixes #66 