### PR TITLE
Episode MonadError

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ It can be achieved using **ngrok** simply following this [comprehensive guide](h
 ### Handling errors
 There's a lot of things that may go wrong during your scenarios executions, 
 from user input to the network issues.
-For this reason, `Scenario` forms a `MonadError` for any `F` having `ApplicativeError` instance.
-If you're not familiar with this kind of abstractions, you can just use built-in `handleErrorWith` and `attempt` methods,
+For this reason, `Scenario` has `MonadError` instance for any `F`.  
+It means that you can use built-in `handleErrorWith` and `attempt` methods,
 in order to react to the raised error or ensure that bot workflow won't break.
 Full example may be found [here](https://github.com/augustjune/canoe/blob/master/examples/src/main/scala/samples/ErrorHandling.scala).
 

--- a/core/src/main/scala/canoe/api/Scenario.scala
+++ b/core/src/main/scala/canoe/api/Scenario.scala
@@ -4,7 +4,7 @@ import canoe.api.matching.Episode
 import canoe.models.messages.TelegramMessage
 import canoe.syntax.Expect
 import cats.arrow.FunctionK
-import cats.{MonadError, StackSafeMonad, ~>}
+import cats.{ApplicativeError, MonadError, StackSafeMonad, ~>}
 import fs2.Pipe
 
 /**
@@ -25,7 +25,8 @@ final class Scenario[F[_], +A] private (private val ep: Episode[F, TelegramMessa
     *
     * Should be used in order to translate this scenario into a fs2.Stream.
     */
-  def pipe: Pipe[F, TelegramMessage, A] = ep.matching
+  def pipe(implicit F: ApplicativeError[F, Throwable]): Pipe[F, TelegramMessage, A] =
+    ep.matching
 
   /**
     * Chains this scenario with the one produced by applying `fn` to the result of this scenario.
@@ -141,6 +142,10 @@ object Scenario {
 
   /**
     * Lifts error value to the Scenario context.
+    *
+    * Error can be safely brought back to the return value domain using `attempt` method.
+    * It also can be handled using various methods from `MonadError`
+    * such as `handleErrorWith`, `recover` etc.
     *
     * @return Scenario which fails with `e`
     */

--- a/core/src/main/scala/canoe/api/matching/Episode.scala
+++ b/core/src/main/scala/canoe/api/matching/Episode.scala
@@ -3,7 +3,7 @@ package canoe.api.matching
 import canoe.api.matching.Episode._
 import cats.instances.list._
 import cats.syntax.all._
-import cats.{ApplicativeError, Monad, MonadError, StackSafeMonad, ~>}
+import cats.{MonadError, StackSafeMonad, ~>}
 import fs2.{Pipe, Pull, Stream}
 
 /**
@@ -54,11 +54,13 @@ object Episode {
 
   private[api] final case class Pure[F[_], A](a: A) extends Episode[F, Any, A]
 
-  private[api] final case class Eval[F[_], A](fa: F[A]) extends Episode[F, Any, A]
-
   private[api] final case class Next[F[_], A](p: A => Boolean) extends Episode[F, A, A]
 
   private[api] final case class First[F[_], A](p: A => Boolean) extends Episode[F, A, A]
+
+  private[api] final case class Eval[F[_], A](fa: F[A]) extends Episode[F, Any, A]
+
+  private[api] final case class RaiseError[F[_]](e: Throwable) extends Episode[F, Any, Nothing]
 
   private[api] final case class Protected[F[_], I, O1, O2 >: O1](episode: Episode[F, I, O1],
                                                                  onError: Throwable => Episode[F, I, O2])
@@ -75,7 +77,7 @@ object Episode {
   private[api] final case class Tolerate[F[_], I, O](episode: Episode[F, I, O], limit: Option[Int], fn: I => F[Unit])
       extends Episode[F, I, O]
 
-  private[api] implicit def monadErrorInstance[F[_]: ApplicativeError[*[_], Throwable], I]
+  private[api] implicit def monadErrorInstance[F[_], I]
     : MonadError[Episode[F, I, *], Throwable] =
     new MonadError[Episode[F, I, *], Throwable] with StackSafeMonad[Episode[F, I, *]] {
 
@@ -87,18 +89,8 @@ object Episode {
       def handleErrorWith[A](fa: Episode[F, I, A])(f: Throwable => Episode[F, I, A]): Episode[F, I, A] =
         Protected(fa, f)
 
-      def raiseError[A](e: Throwable): Episode[F, I, A] = Eval(e.raiseError[F, A])
-    }
-
-  private[api] implicit def monadInstance[F[_], I]: Monad[Episode[F, I, *]] =
-    new StackSafeMonad[Episode[F, I, *]] {
-
-      def pure[A](a: A): Episode[F, I, A] = Pure(a)
-
-      def flatMap[A, B](
-        episode: Episode[F, I, A]
-      )(fn: A => Episode[F, I, B]): Episode[F, I, B] =
-        episode.flatMap(fn)
+      def raiseError[A](e: Throwable): Episode[F, I, A] =
+        RaiseError(e)
     }
 
   private sealed trait Result[+I, +O] {
@@ -123,18 +115,6 @@ object Episode {
     episode match {
       case Pure(a) =>
         Stream(a).covary[F].map(o => Matched(o) -> input)
-
-      case Protected(episode, onError) =>
-        find(episode, input, cancelTokens).flatMap {
-          case (Failed(e), rest) => find(onError(e), rest, cancelTokens)
-          case other             => Stream(other)
-        }
-
-      case Eval(fa) =>
-        Stream
-          .eval(fa)
-          .map(o => Matched(o) -> input)
-          .handleErrorWith(e => Stream(Failed(e) -> input))
 
       case First(p: (I => Boolean)) =>
         def go(in: Stream[F, I]): Pull[F, (Result[I, O], Stream[F, I]), Unit] =
@@ -166,6 +146,21 @@ object Episode {
           }
 
         go(input).stream
+
+      case Eval(fa) =>
+        Stream
+          .eval(fa)
+          .map(o => Matched(o) -> input)
+          .handleErrorWith(e => Stream(Failed(e) -> input))
+
+      case RaiseError(e) =>
+        Stream(Failed(e) -> input)
+
+      case Protected(episode, onError) =>
+        find(episode, input, cancelTokens).flatMap {
+          case (Failed(e), rest) => find(onError(e), rest, cancelTokens)
+          case other             => Stream(other)
+        }
 
       case Cancellable(episode, p, f) =>
         find(episode, input, (p, f) :: cancelTokens)
@@ -203,9 +198,10 @@ object Episode {
   private def translate[F[_], G[_], I, O](episode: Episode[F, I, O], f: F ~> G): Episode[G, I, O] =
     episode match {
       case Pure(a)                    => Pure(a)
-      case Eval(fa)                   => Eval(f(fa))
       case Next(p)                    => Next(p).asInstanceOf[Episode[G, I, O]]
       case First(p)                   => First(p).asInstanceOf[Episode[G, I, O]]
+      case Eval(fa)                   => Eval(f(fa))
+      case RaiseError(e)              => RaiseError(e)
       case Protected(ep, onError)     => Protected(ep.mapK(f), onError.andThen(_.mapK(f)))
       case Bind(ep, fn)               => Bind(ep.mapK(f), fn.andThen(_.mapK(f)))
       case Tolerate(ep, limit, fn)    => Tolerate(ep.mapK(f), limit, fn.andThen(f(_)))

--- a/core/src/test/scala/canoe/api/ScenarioLawsCheck.scala
+++ b/core/src/test/scala/canoe/api/ScenarioLawsCheck.scala
@@ -1,7 +1,6 @@
 package canoe.api
 
 import canoe.api.ScenarioCheckInstances._
-import cats.Monad
 import cats.effect.IO
 import cats.implicits._
 import cats.laws.discipline._
@@ -9,13 +8,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.typelevel.discipline.scalatest.Discipline
 
 class ScenarioLawsCheck extends AnyFunSuite with Discipline {
-
-  // By re-declaring implicit Monad instance here, we ensure that it will be used during monad tests,
-  // instead of MonadError instance
-  implicit def monadInstance[F[_], I]: Monad[Scenario[F, *]] = Scenario.monadInstance
-
-  checkAll("Monad[Scenario[IO, *]]",
-    MonadTests[Scenario[IO, *]].monad[Int, String, Int])
 
   checkAll("MonadError[Scenario[IO, *], Throwable]",
     MonadErrorTests[Scenario[IO, *], Throwable].monadError[String, Int, String])

--- a/core/src/test/scala/canoe/api/matching/EpisodeLawsCheck.scala
+++ b/core/src/test/scala/canoe/api/matching/EpisodeLawsCheck.scala
@@ -1,7 +1,6 @@
 package canoe.api.matching
 
 import canoe.api.matching.EpisodeCheckInstances._
-import cats.Monad
 import cats.effect.IO
 import cats.implicits._
 import cats.laws.discipline._
@@ -9,13 +8,6 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.typelevel.discipline.scalatest.Discipline
 
 class EpisodeLawsCheck extends AnyFunSuite with Discipline {
-
-  // By re-declaring implicit Monad instance here we ensure that it will be used during monad tests,
-  // instead of MonadError instance
-  implicit def monadInstance[F[_], I]: Monad[Episode[F, I, *]] = Episode.monadInstance
-
-  checkAll("Monad[Episode[IO, Int, *]]",
-    MonadTests[Episode[IO, Int, *]].monad[Int, Int, Int])
 
   checkAll("MonadError[Episode[IO, Int, *], Throwable]",
     MonadErrorTests[Episode[IO, Int, *], Throwable].monadError[Int, Int, Int])

--- a/examples/src/main/scala/samples/Composition.scala
+++ b/examples/src/main/scala/samples/Composition.scala
@@ -67,10 +67,10 @@ object Composition extends IOApp {
       pass      <- enterPass(chat)
       _         <- Scenario.eval(chat.send("Repeat your password"))
       reentered <- enterPass(chat)
-      _ <-
-        if (pass == reentered) Scenario.eval(chat.send("Your password is stored."))
+      r <-
+        if (pass == reentered) Scenario.eval(chat.send("Your password is stored.")).as(pass)
         else Scenario.eval(chat.send("Provided passwords don't match. Try again")) >> providePass(chat)
-    } yield pass
+    } yield r
 
   def enterPass[F[_]: TelegramClient](chat: Chat): Scenario[F, String] =
     for {

--- a/examples/src/main/scala/samples/ErrorHandling.scala
+++ b/examples/src/main/scala/samples/ErrorHandling.scala
@@ -12,8 +12,8 @@ import fs2.Stream
   * Here `Scenario#attempt` method is used, but the same (and more)
   * may be achieved with `Scenario#handleErrorWith`.
   *
-  * Also having `ApplicativeError[F, Throwable]` instance for your effect type
-  * will allow you to raise errors inside the scenario with `Scenario#raiseError` method.
+  * Also using `Scenario#raiseError` method you can lift error value
+  * in order to represent failing scenario.
   */
 object ErrorHandling extends IOApp {
 


### PR DESCRIPTION
* Provides `MonadError` instance for `Episode` and `Scenario` without any restriction in `F`
* Makes sure that encountered errors are suspended into `Stream` during scenario interpretation