### PR TITLE
Unknown update

### DIFF
--- a/core/shared/src/main/scala/canoe/api/sources/Polling.scala
+++ b/core/shared/src/main/scala/canoe/api/sources/Polling.scala
@@ -31,12 +31,6 @@ private[api] class Polling[F[_]: TelegramClient: ApplicativeError[*[_], Throwabl
   private def requestUpdates(offset: Long): F[(Long, List[Update])] =
     GetUpdates(offset = Some(offset), timeout = Some(timeout.toSeconds.toInt)).call
       .map(updates => (lastId(updates).map(_ + 1).getOrElse(offset), updates))
-      .recover {
-        case ResponseDecodingError(json) =>
-          val updates = successfulUpdates(json)
-          val nextOffset = lastId(updates).map(_ + 1).getOrElse(offset)
-          nextOffset -> updates
-      }
 
   private def successfulUpdates(json: String): List[Update] =
     decode(json)(GetUpdates.accumulativeDecoder).toOption.getOrElse(Nil)

--- a/core/shared/src/main/scala/canoe/models/Update.scala
+++ b/core/shared/src/main/scala/canoe/models/Update.scala
@@ -13,6 +13,8 @@ sealed trait Update {
 
 object Update {
 
+  final case class Unknown(updateId: Long) extends Update
+
   implicit val updateDecoder: Decoder[Update] =
     List[Decoder[Update]](
       deriveDecoder[MessageReceived].widen,
@@ -48,5 +50,3 @@ final case class ShippingQueryReceived(updateId: Long, shippingQuery: ShippingQu
 final case class PreCheckoutQueryReceived(updateId: Long, preCheckoutQuery: PreCheckoutQuery) extends Update
 
 final case class PollUpdated(updateId: Long, poll: Poll) extends Update
-
-final case class Unknown(updateId: Long) extends Update

--- a/core/shared/src/main/scala/canoe/models/Update.scala
+++ b/core/shared/src/main/scala/canoe/models/Update.scala
@@ -24,7 +24,8 @@ object Update {
       deriveDecoder[InlineResultSelected].widen,
       deriveDecoder[CallbackButtonSelected].widen,
       deriveDecoder[ShippingQueryReceived].widen,
-      deriveDecoder[PreCheckoutQueryReceived].widen
+      deriveDecoder[PreCheckoutQueryReceived].widen,
+      deriveDecoder[Unknown].widen
     ).reduceLeft(_.or(_)).camelCase
 }
 
@@ -47,3 +48,5 @@ final case class ShippingQueryReceived(updateId: Long, shippingQuery: ShippingQu
 final case class PreCheckoutQueryReceived(updateId: Long, preCheckoutQuery: PreCheckoutQuery) extends Update
 
 final case class PollUpdated(updateId: Long, poll: Poll) extends Update
+
+final case class Unknown(updateId: Long) extends Update


### PR DESCRIPTION
Adds unknown update case, which is useful in several scenarios:
* handling updates which cannot be deserialized (by ignoring them)
* initial element in bot updates topic, removing overhead caused by wrapping each following update in `Option`
