### PR TITLE
Concurrent scenarios

### DIFF
--- a/core/shared/src/main/scala/canoe/api/Bot.scala
+++ b/core/shared/src/main/scala/canoe/api/Bot.scala
@@ -3,9 +3,10 @@ package canoe.api
 import canoe.api.sources.{Hook, Polling}
 import canoe.models.messages.TelegramMessage
 import canoe.models.{InputFile, Update}
-import cats.effect.concurrent.Ref
+import cats.effect.concurrent.{Deferred, Ref}
 import cats.effect.{Concurrent, ConcurrentEffect, Resource, Timer}
-import fs2.concurrent.{Queue, Topic}
+import cats.syntax.all._
+import fs2.concurrent.Topic
 import fs2.{Pipe, Stream}
 
 import scala.concurrent.duration.FiniteDuration
@@ -59,60 +60,40 @@ class Bot[F[_]: Concurrent] private[api] (source: UpdateSource[F]) {
     */
   def follow(scenarios: Scenario[F, Unit]*): Stream[F, Update] = {
 
-    def filterById(id: Long): Pipe[F, TelegramMessage, TelegramMessage] =
-      _.filter(_.chat.id == id)
+    def filterMessages(id: Long): Pipe[F, Update, TelegramMessage] =
+      _.through(pipes.messages).filter(_.chat.id == id)
 
-    def register(idsRef: Ref[F, Set[Long]], id: Long): F[Boolean] =
-      idsRef.modify { ids =>
-        val was = ids.contains(id)
-        ids + id -> was
+    def debounce[F[_]: Concurrent, A](in: Stream[F, A]): Stream[F, A] =
+      Stream.eval(Ref[F].of[Option[Deferred[F, A]]](None)).flatMap { ref =>
+        val hook = Stream
+          .repeatEval(Deferred[F, A])
+          .evalMap(df => ref.set(Some(df)) *> df.get)
+
+        val update = in.evalMap(
+          a =>
+            ref.getAndSet(None).flatMap {
+              case Some(df) => df.complete(a)
+              case None     => Concurrent[F].unit
+            }
+        )
+
+        hook.concurrently(update)
       }
 
-    def runSingle(scenario: Scenario[F, Unit],
-                  idsRef: Ref[F, Set[Long]],
-                  topic: Topic[F, Update]): Stream[F, Nothing] =
-      topic
+    def track(updates: Topic[F, Update], m: TelegramMessage): Stream[F, TelegramMessage] =
+      debounce(updates.subscribe(1).through(filterMessages(m.chat.id))).cons1(m)
+
+    def runScenarios(updates: Topic[F, Update]): Stream[F, Nothing] =
+      updates
         .subscribe(1)
         .through(pipes.messages)
-        .map { m =>
-          Stream
-            .eval(register(idsRef, m.chat.id))
-            .flatMap { existed =>
-              if (existed) Stream.empty
-              else
-                //  Using queues in order to avoid blocking topic publisher
-                Stream.eval(Queue.unbounded[F, TelegramMessage]).flatMap { queue =>
-                  val enq = topic
-                    .subscribe(1)
-                    .through(pipes.messages andThen filterById(m.chat.id))
-                    .through(queue.enqueue)
-
-                  val deq = queue.dequeue.through(scenario.pipe).drain
-
-                  deq.concurrently(enq)
-                }
-            }
-        }
+        .map(m => Stream.emits(scenarios).map(sc => track(updates, m).through(sc.pipe).take(1)).parJoinUnbounded.drain)
         .parJoinUnbounded
-
-    def runAll(scenarios: List[Scenario[F, Unit]],
-               updates: Stream[F, Update],
-               topic: Topic[F, Update]): Stream[F, Update] = {
-
-      val run = Stream
-        .emits(scenarios)
-        .zipWith(Stream.repeatEval(Ref[F].of(Set.empty[Long]))) {
-          case (scenario, ids) => runSingle(scenario, ids, topic)
-        }
-        .parJoinUnbounded
-
-      val populate = updates.evalTap(u => topic.publish1(u))
-
-      populate.concurrently(run)
-    }
 
     Stream.eval(Topic[F, Update](Update.Unknown(-1L))).flatMap { topic =>
-      runAll(scenarios.toList, updates, topic)
+      val pop = updates.evalTap(topic.publish1)
+      val run = runScenarios(topic)
+      pop.concurrently(run)
     }
   }
 }

--- a/core/shared/src/main/scala/canoe/api/Bot.scala
+++ b/core/shared/src/main/scala/canoe/api/Bot.scala
@@ -81,7 +81,7 @@ class Bot[F[_]: Concurrent] private[api] (source: UpdateSource[F]) {
       }
 
     def track(updates: Topic[F, Update], m: TelegramMessage): Stream[F, TelegramMessage] =
-      debounce(updates.subscribe(1).through(filterMessages(m.chat.id))).cons1(m)
+      debounce(updates.subscribe(1).through(filterMessages(m.chat.id)))
 
     def runScenarios(updates: Topic[F, Update]): Stream[F, Nothing] =
       updates

--- a/core/shared/src/main/scala/canoe/api/Scenario.scala
+++ b/core/shared/src/main/scala/canoe/api/Scenario.scala
@@ -26,7 +26,7 @@ final class Scenario[F[_], +A] private (private val ep: Episode[F, TelegramMessa
     * Should be used in order to translate this scenario into a fs2.Stream.
     */
   def pipe(implicit F: ApplicativeError[F, Throwable]): Pipe[F, TelegramMessage, A] =
-    ep.matching
+    ep.sequential
 
   /**
     * Chains this scenario with the one produced by applying `fn` to the result of this scenario.

--- a/core/shared/src/main/scala/canoe/api/matching/Episode.scala
+++ b/core/shared/src/main/scala/canoe/api/matching/Episode.scala
@@ -134,7 +134,7 @@ object Episode {
         def go(in: Stream[F, I]): Pull[F, (Result[I, O], Stream[F, I]), Unit] =
           in.pull.uncons1.attempt.flatMap {
             case Left(e) => Pull.output1(Failed(e) -> Stream.empty)
-            case Right(Some(a -> rest)) =>
+            case Right(Some((a, rest))) =>
               cancelTokens.collect { case (p, f) if p(a) => f } match {
                 case Nil =>
                   if (p(a)) Pull.output1(Matched(a.asInstanceOf[O]) -> rest)

--- a/core/shared/src/test/scala/canoe/api/BotSpec.scala
+++ b/core/shared/src/test/scala/canoe/api/BotSpec.scala
@@ -22,8 +22,7 @@ class BotSpec extends AnyFunSuite {
           .emits(messages.zipWithIndex.map {
             case ((m, id), i) => MessageReceived(i, TextMessage(i, PrivateChat(id, None, None, None), -1, m))
           })
-          .covary[IO]
-          .metered(0.2.second)
+          .metered[IO](0.3.second)
     }
 
   test("updates returns updates from the source") {

--- a/core/shared/src/test/scala/canoe/api/ScenarioSpec.scala
+++ b/core/shared/src/test/scala/canoe/api/ScenarioSpec.scala
@@ -34,7 +34,6 @@ class ScenarioSpec extends AnyPropSpec {
     val input = Stream(
       trigger,
       trigger,
-      "dasd",
       trigger
     ).map(message)
 

--- a/core/shared/src/test/scala/canoe/api/ScenarioSpec.scala
+++ b/core/shared/src/test/scala/canoe/api/ScenarioSpec.scala
@@ -13,6 +13,13 @@ class ScenarioSpec extends AnyPropSpec {
   private def message(s: String): TextMessage =
     TextMessage(-1, PrivateChat(-1, None, None, None), -1, s)
 
+  property("Scenario.start returns finishes if the first element is not matched") {
+    val scenario: Scenario[IO, TextMessage] = Scenario.start(command("fire"))
+    val input = Stream(message("not matched"), message("fire"))
+
+    assert(input.through(scenario.pipe).toList().isEmpty)
+  }
+
   property("Scenario.start consumes at least one message") {
     val scenario: Scenario[IO, TextMessage] = Scenario.start(command("fire"))
     val input = Stream.empty


### PR DESCRIPTION
Replaces the way scenarios are followed by the bot, i.e. each scenario individual is executed on its own logical thread and is started on each input element.