### PR TITLE
Limiting the period of scenario lifetime

### DIFF
--- a/core/shared/src/main/scala/canoe/api/Bot.scala
+++ b/core/shared/src/main/scala/canoe/api/Bot.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration.FiniteDuration
   * An instance which can communicate with Telegram service and
   * interact with other Telegram users in a certain predefined way
   */
-class Bot[F[_]: Concurrent] private[api] (val updates: Stream[F, Update]) {
+class Bot[F[_]: Concurrent: Timer] private[api] (val updates: Stream[F, Update]) {
 
   /**
     * Defines the behavior of the bot.
@@ -99,14 +99,14 @@ object Bot {
   /**
     * Creates a bot which operates on provided updates. 
     */
-  def fromStream[F[_]: Concurrent](updates: Stream[F, Update]): Bot[F] = new Bot(updates)
+  def fromStream[F[_]: Concurrent: Timer](updates: Stream[F, Update]): Bot[F] = new Bot(updates)
   
   /**
     * Creates a bot which receives incoming updates using long polling mechanism.
     *
     * See [[https://en.wikipedia.org/wiki/Push_technology#Long_polling wiki]].
     */
-  def polling[F[_]: Concurrent: TelegramClient]: Bot[F] =
+  def polling[F[_]: Concurrent: Timer: TelegramClient]: Bot[F] =
     new Bot[F](Polling.continual)
 
   /**

--- a/core/shared/src/main/scala/canoe/api/matching/Episode.scala
+++ b/core/shared/src/main/scala/canoe/api/matching/Episode.scala
@@ -1,15 +1,13 @@
 package canoe.api.matching
 
-import Episode._
+import canoe.api.matching.Episode._
+import cats.effect.{Bracket, Concurrent, ExitCase, Timer}
 import cats.instances.list._
 import cats.syntax.all._
-import cats.{~>, MonadError, StackSafeMonad}
+import cats.~>
 import fs2.{Pipe, Pull, Stream}
-import cats.effect.Bracket
-import cats.effect.ExitCase
+
 import scala.concurrent.duration.FiniteDuration
-import cats.effect.Concurrent
-import cats.effect.Timer
 
 /**
   * Type which represents a description of sequence of elements.
@@ -116,20 +114,6 @@ object Episode {
           case Right(b) => pure(b)
         }
 
-    }
-
-  private[api] implicit def monadErrorInstance[F[_], I]: MonadError[Episode[F, I, *], Throwable] =
-    new MonadError[Episode[F, I, *], Throwable] with StackSafeMonad[Episode[F, I, *]] {
-      def pure[A](a: A): Episode[F, I, A] = Pure(a)
-
-      def flatMap[A, B](fa: Episode[F, I, A])(f: A => Episode[F, I, B]): Episode[F, I, B] =
-        fa.flatMap(f)
-
-      def handleErrorWith[A](fa: Episode[F, I, A])(f: Throwable => Episode[F, I, A]): Episode[F, I, A] =
-        Protected(fa, f)
-
-      def raiseError[A](e: Throwable): Episode[F, I, A] =
-        RaiseError(e)
     }
 
   private sealed trait Result[+I, +O] {


### PR DESCRIPTION
This PR adds two features:
* `Bracket` instance for `Scenario` class, replacing existing `MonadError` instance
* `within` combinator in `Scenario` API that allows specifying the duration after which scenario gets canceled.

Closes #158 