### PR TITLE
Removed unnecessary string quotes on multipart request

### DIFF
--- a/core/jvm/src/main/scala/canoe/api/clients/Http4sTelegramClient.scala
+++ b/core/jvm/src/main/scala/canoe/api/clients/Http4sTelegramClient.scala
@@ -64,7 +64,10 @@ private[api] class Http4sTelegramClient[F[_]: Sync: Logger](token: String, clien
         .map(
           _.toIterable
             .filterNot(kv => kv._2.isNull || kv._2.isObject)
-            .map { case (k, j) => k -> j.toString }
+            .map {
+              case (k, j) if j.isString => k -> j.asString.get
+              case (k, j) => k -> j.toString
+            }
             .toMap
         )
         .getOrElse(Map.empty)


### PR DESCRIPTION
When sending any media file with caption user sees quoted message.
If parseMode html or markdown enabled then telegram returns error.
so this fix removes unnecessary quotes