### PR TITLE
Add support for layer 133

### DIFF
--- a/core/shared/src/main/scala/canoe/api/models/ChatApi.scala
+++ b/core/shared/src/main/scala/canoe/api/models/ChatApi.scala
@@ -62,7 +62,7 @@ final class ChatApi(private val chat: Chat) extends AnyVal {
   /**
     * @return Detailed information about the member of this chat.
     */
-  def getMember[F[_]: TelegramClient](userId: Int): F[ChatMember] =
+  def getMember[F[_]: TelegramClient](userId: Long): F[ChatMember] =
     GetChatMember(chat.id, userId).call
 
   /**
@@ -74,7 +74,7 @@ final class ChatApi(private val chat: Chat) extends AnyVal {
   /**
     * Kicks a user from this chat.
     */
-  def kickUser[F[_]: TelegramClient: Applicative](userId: Int, untilDate: Option[Int] = None): F[Boolean] =
+  def kickUser[F[_]: TelegramClient: Applicative](userId: Long, untilDate: Option[Int] = None): F[Boolean] =
     chat match {
       case _: PrivateChat => false.pure[F]
       case _              => KickChatMember(chat.id, userId, untilDate).call
@@ -105,7 +105,7 @@ final class ChatApi(private val chat: Chat) extends AnyVal {
   /**
     * Promotes or demotes a user in this chat.
     */
-  def promoteMember[F[_]: TelegramClient: Applicative](userId: Int,
+  def promoteMember[F[_]: TelegramClient: Applicative](userId: Long,
                                                        canChangeInfo: Option[Boolean] = None,
                                                        canPostMessages: Option[Boolean] = None,
                                                        canEditMessages: Option[Boolean] = None,
@@ -138,7 +138,7 @@ final class ChatApi(private val chat: Chat) extends AnyVal {
     * The bot must be an administrator in the supergroup
     * and must have the appropriate admin rights.
     */
-  def restrictMember[F[_]: TelegramClient: Applicative](userId: Int,
+  def restrictMember[F[_]: TelegramClient: Applicative](userId: Long,
                                                         permissions: ChatPermissions,
                                                         until: Option[Int] = None
   ): F[Boolean] =
@@ -181,7 +181,7 @@ final class ChatApi(private val chat: Chat) extends AnyVal {
   /**
     * Unbans previously kicked user.
     */
-  def unbanMember[F[_]: TelegramClient](userId: Int): F[Boolean] =
+  def unbanMember[F[_]: TelegramClient](userId: Long): F[Boolean] =
     UnbanChatMember(chat.id, userId).call
 
   /**

--- a/core/shared/src/main/scala/canoe/methods/chats/GetChatMember.scala
+++ b/core/shared/src/main/scala/canoe/methods/chats/GetChatMember.scala
@@ -15,7 +15,7 @@ import io.circe.{Decoder, Encoder}
   *               (in the format @channelusername)
   * @param userId Unique identifier of the target user
   */
-final case class GetChatMember(chatId: ChatId, userId: Int)
+final case class GetChatMember(chatId: ChatId, userId: Long)
 
 object GetChatMember {
 

--- a/core/shared/src/main/scala/canoe/methods/chats/KickChatMember.scala
+++ b/core/shared/src/main/scala/canoe/methods/chats/KickChatMember.scala
@@ -22,7 +22,7 @@ import io.circe.{Decoder, Encoder}
   *                  If user is banned for more than 366 days or less than 30 seconds from the current time
   *                  they are considered to be banned forever
   */
-final case class KickChatMember(chatId: ChatId, userId: Int, untilDate: Option[Int] = None)
+final case class KickChatMember(chatId: ChatId, userId: Long, untilDate: Option[Int] = None)
 
 object KickChatMember {
 

--- a/core/shared/src/main/scala/canoe/methods/chats/PromoteChatMember.scala
+++ b/core/shared/src/main/scala/canoe/methods/chats/PromoteChatMember.scala
@@ -28,7 +28,7 @@ import io.circe.{Decoder, Encoder}
   *                           directly or indirectly (promoted by administrators that were appointed by him)
   */
 final case class PromoteChatMember(chatId: ChatId,
-                                   userId: Int,
+                                   userId: Long,
                                    canChangeInfo: Option[Boolean] = None,
                                    canPostMessages: Option[Boolean] = None,
                                    canEditMessages: Option[Boolean] = None,

--- a/core/shared/src/main/scala/canoe/methods/chats/RestrictChatMember.scala
+++ b/core/shared/src/main/scala/canoe/methods/chats/RestrictChatMember.scala
@@ -19,7 +19,7 @@ import io.circe.{Decoder, Encoder}
   *                    they are considered to be banned forever
   */
 final case class RestrictChatMember(chatId: ChatId,
-                                    userId: Int,
+                                    userId: Long,
                                     permissions: ChatPermissions,
                                     untilDate: Option[Int] = None)
 

--- a/core/shared/src/main/scala/canoe/methods/chats/SetChatAdministratorCustomTitle.scala
+++ b/core/shared/src/main/scala/canoe/methods/chats/SetChatAdministratorCustomTitle.scala
@@ -6,7 +6,7 @@ import canoe.models.{ChatId, InputFile}
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.deriveEncoder
 
-final case class SetChatAdministratorCustomTitle(chatId: ChatId, userId: Int, customTitle: String)
+final case class SetChatAdministratorCustomTitle(chatId: ChatId, userId: Long, customTitle: String)
 
 object SetChatAdministratorCustomTitle {
 

--- a/core/shared/src/main/scala/canoe/methods/chats/UnbanChatMember.scala
+++ b/core/shared/src/main/scala/canoe/methods/chats/UnbanChatMember.scala
@@ -17,7 +17,7 @@ import io.circe.{Decoder, Encoder}
   *               (in the format @channelusername)
   * @param userId Unique identifier of the target user
   */
-final case class UnbanChatMember(chatId: ChatId, userId: Int)
+final case class UnbanChatMember(chatId: ChatId, userId: Long)
 
 object UnbanChatMember {
 

--- a/core/shared/src/main/scala/canoe/methods/games/GetGameHighScores.scala
+++ b/core/shared/src/main/scala/canoe/methods/games/GetGameHighScores.scala
@@ -26,7 +26,7 @@ import io.circe.{Decoder, Encoder}
   * @param inlineMessageId Identifier of the inline message.
   *                        Required if 'chatId' and 'messageId' are not specified.
   */
-final class GetGameHighScores private (val userId: Int,
+final class GetGameHighScores private (val userId: Long,
                                        val chatId: Option[ChatId] = None,
                                        val messageId: Option[Int] = None,
                                        val inlineMessageId: Option[String] = None)
@@ -37,13 +37,13 @@ object GetGameHighScores {
   /**
     * For the messages sent directly by the bot
     */
-  def direct(chatId: ChatId, messageId: Int, userId: Int): GetGameHighScores =
+  def direct(chatId: ChatId, messageId: Int, userId: Long): GetGameHighScores =
     new GetGameHighScores(userId, Some(chatId), Some(messageId))
 
   /**
     * For the inlined messages sent via the bot
     */
-  def inlined(inlineMessageId: String, userId: Int): GetGameHighScores =
+  def inlined(inlineMessageId: String, userId: Long): GetGameHighScores =
     new GetGameHighScores(userId, inlineMessageId = Some(inlineMessageId))
 
   implicit val method: Method[GetGameHighScores, List[GameHighScore]] =

--- a/core/shared/src/main/scala/canoe/methods/games/SetGameScore.scala
+++ b/core/shared/src/main/scala/canoe/methods/games/SetGameScore.scala
@@ -29,7 +29,7 @@ import io.circe.{Decoder, Encoder}
   * @param inlineMessageId    Identifier of the inline message.
   *                           Required if 'chatId' and 'messageId' are not specified.
   */
-final class SetGameScore private (val userId: Int,
+final class SetGameScore private (val userId: Long,
                                   val score: Long,
                                   val force: Option[Boolean],
                                   val disableEditMessage: Option[Boolean],
@@ -43,7 +43,7 @@ object SetGameScore {
     */
   def direct(chatId: ChatId,
              messageId: Int,
-             userId: Int,
+             userId: Long,
              score: Long,
              force: Option[Boolean] = None,
              disableEditMessage: Option[Boolean] = None): SetGameScore =
@@ -53,7 +53,7 @@ object SetGameScore {
     * For the inlined messages sent via the bot
     */
   def inlined(inlineMessageId: String,
-              userId: Int,
+              userId: Long,
               score: Long,
               force: Option[Boolean] = None,
               disableEditMessage: Option[Boolean] = None): SetGameScore =

--- a/core/shared/src/main/scala/canoe/methods/passport/SetPassportDataErrors.scala
+++ b/core/shared/src/main/scala/canoe/methods/passport/SetPassportDataErrors.scala
@@ -14,7 +14,7 @@ import io.circe.{Decoder, Encoder}
   *
   * Returns True on success.
   */
-final case class SetPassportDataErrors(userId: Int, errors: List[PassportElementError])
+final case class SetPassportDataErrors(userId: Long, errors: List[PassportElementError])
 
 object SetPassportDataErrors {
   import io.circe.generic.auto._

--- a/core/shared/src/main/scala/canoe/methods/stickers/AddStickerToSet.scala
+++ b/core/shared/src/main/scala/canoe/methods/stickers/AddStickerToSet.scala
@@ -21,7 +21,7 @@ import cats.syntax.all._
   * @param emojis       One or more emoji corresponding to the sticker
   * @param maskPosition Position where the mask should be placed on faces
   */
-final class AddStickerToSet private (val userId: Int,
+final class AddStickerToSet private (val userId: Long,
                                      val name: String,
                                      val pngSticker: Option[InputFile],
                                      val tgsSticker: Option[InputFile],
@@ -33,7 +33,7 @@ object AddStickerToSet {
   /**
     * @param sticker PNG image with the sticker.
     */
-  def static(userId: Int,
+  def static(userId: Long,
              name: String,
              sticker: InputFile,
              emojis: String,
@@ -45,7 +45,7 @@ object AddStickerToSet {
     * @param sticker TGS animation with the sticker.
     * Animated stickers can be added to animated sticker sets and only to them.
     */
-  def animated(userId: Int,
+  def animated(userId: Long,
                name: String,
                sticker: InputFile,
                emojis: String,

--- a/core/shared/src/main/scala/canoe/methods/stickers/CreateNewStickerSet.scala
+++ b/core/shared/src/main/scala/canoe/methods/stickers/CreateNewStickerSet.scala
@@ -30,7 +30,7 @@ import cats.syntax.all._
   * @param containsMasks Pass True, if a set of mask stickers should be created
   * @param maskPosition  Position where the mask should be placed on faces
   */
-final class CreateNewStickerSet private (val userId: Int,
+final class CreateNewStickerSet private (val userId: Long,
                                          val name: String,
                                          val title: String,
                                          val pngSticker: Option[InputFile],
@@ -46,7 +46,7 @@ object CreateNewStickerSet {
     * Static sticker sets can have up to 120 stickers.
     * Note: Animated stickers can be added to animated sticker sets and only to them.
     */
-  def static(userId: Int,
+  def static(userId: Long,
              name: String,
              title: String,
              sticker: InputFile,
@@ -59,7 +59,7 @@ object CreateNewStickerSet {
   /**
     * Animated sticker sets can have up to 50 stickers.
     */
-  def animated(userId: Int,
+  def animated(userId: Long,
                name: String,
                title: String,
                sticker: InputFile,

--- a/core/shared/src/main/scala/canoe/methods/stickers/SetStickerSetThumb.scala
+++ b/core/shared/src/main/scala/canoe/methods/stickers/SetStickerSetThumb.scala
@@ -15,7 +15,7 @@ import canoe.marshalling.codecs._
   * @param thumb  A PNG image with the thumbnail, must be up to 128 kilobytes in size and have width and height exactly 100px,
   *               or a TGS animation with the thumbnail up to 32 kilobytes in size;
   */
-final case class SetStickerSetThumb(name: String, userId: Int, thumb: InputFile)
+final case class SetStickerSetThumb(name: String, userId: Long, thumb: InputFile)
 
 object SetStickerSetThumb {
   implicit val method: Method[SetStickerSetThumb, Boolean] =

--- a/core/shared/src/main/scala/canoe/methods/stickers/UploadStickerFile.scala
+++ b/core/shared/src/main/scala/canoe/methods/stickers/UploadStickerFile.scala
@@ -16,7 +16,7 @@ import io.circe.{Decoder, Encoder}
   *                    dimensions must not exceed 512px, and either width or height must be exactly 512px.
   *                    [[https://core.telegram.org/bots/api#sending-files More info on Sending Files]]
   */
-final case class UploadStickerFile(userId: Int, pngSticker: InputFile)
+final case class UploadStickerFile(userId: Long, pngSticker: InputFile)
 
 object UploadStickerFile {
   import io.circe.generic.auto._

--- a/core/shared/src/main/scala/canoe/methods/users/GetUserProfilePhotos.scala
+++ b/core/shared/src/main/scala/canoe/methods/users/GetUserProfilePhotos.scala
@@ -15,7 +15,7 @@ import io.circe.{Decoder, Encoder}
   * @param limit  Limits the number of photos to be retrieved.
   *               Values between 1-100 are accepted. Defaults to 100.
   */
-final case class GetUserProfilePhotos(userId: Int, offset: Option[Int] = None, limit: Option[Int] = None)
+final case class GetUserProfilePhotos(userId: Long, offset: Option[Int] = None, limit: Option[Int] = None)
 
 object GetUserProfilePhotos {
   import io.circe.generic.auto._

--- a/core/shared/src/main/scala/canoe/models/Contact.scala
+++ b/core/shared/src/main/scala/canoe/models/Contact.scala
@@ -12,5 +12,5 @@ package canoe.models
 final case class Contact(phoneNumber: String,
                          firstName: String,
                          lastName: Option[String],
-                         userId: Option[Int],
+                         userId: Option[Long],
                          vcard: Option[String])

--- a/core/shared/src/main/scala/canoe/models/User.scala
+++ b/core/shared/src/main/scala/canoe/models/User.scala
@@ -13,7 +13,7 @@ package canoe.models
   * @param canReadAllGroupMessages True, if privacy mode is disabled for the bot. Returned only in getMe.
   * @param supportsInlineQueries   True, if the bot supports inline queries. Returned only in getMe.
   */
-final case class User(id: Int,
+final case class User(id: Long,
                       isBot: Boolean,
                       firstName: String,
                       lastName: Option[String],

--- a/examples/src/main/scala/samples/CustomExtractor.scala
+++ b/examples/src/main/scala/samples/CustomExtractor.scala
@@ -21,13 +21,13 @@ object CustomExtractor extends IOApp {
       .drain
       .as(ExitCode.Success)
 
-  def greetParticularUser[F[_]: TelegramClient](userId: Int): Scenario[F, Unit] =
+  def greetParticularUser[F[_]: TelegramClient](userId: Long): Scenario[F, Unit] =
     for {
       msg <- Scenario.expect(particularUsersMessages(userId))
       _   <- Scenario.eval(msg.chat.send(s"I was waiting for you ${name(msg)}"))
     } yield ()
 
-  def particularUsersMessages(userId: Int): Expect[UserMessage] = {
+  def particularUsersMessages(userId: Long): Expect[UserMessage] = {
     case m: UserMessage if m.from.map(_.id).contains(userId) => m
   }
 


### PR DESCRIPTION
Telegram has recently moved from 32 bit ids to 64 bit ones, and since canoe doesn't support the later new users can't interacts with bots - the bots just cant parse user messages.

This should fix it. 